### PR TITLE
fix: includes error_tracker in releases

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,7 @@ defmodule TowerErrorTracker.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
+      included_applications: [:error_tracker],
       extra_applications: [:logger]
     ]
   end


### PR DESCRIPTION
we have `runtime: false` so the `ErrorTracker.Application.start` isnt' executed and attaches handlers, but we still need `ErrorTracker` modules to be available during releases

https://elixirforum.com/t/how-to-exclude-a-dependencys-application-from-running-but-still-include-it-in-the-release/55863