### PR TITLE
feat: workaround for missing Logger messages

### DIFF
--- a/lib/tower_error_tracker/reporter.ex
+++ b/lib/tower_error_tracker/reporter.ex
@@ -1,3 +1,11 @@
+defmodule TowerErrorTracker.ReportedMessage do
+  defexception [:level, :message]
+
+  def message(%{level: level, message: message}) do
+    "[#{level}] #{message}"
+  end
+end
+
 defmodule TowerErrorTracker.Reporter do
   @moduledoc false
 
@@ -15,6 +23,13 @@ defmodule TowerErrorTracker.Reporter do
 
   def report_event(%Tower.Event{kind: :exit, reason: reason, stacktrace: stacktrace} = event) do
     ErrorTracker.report({:exit, Exception.format_exit(reason)}, stacktrace, context(event))
+
+    :ok
+  end
+
+  def report_event(%Tower.Event{kind: :message, reason: reason, level: level} = event) do
+    TowerErrorTracker.ReportedMessage.exception(level: level, message: reason)
+    |> ErrorTracker.report([], context(event))
 
     :ok
   end

--- a/test/tower_error_tracker_test.exs
+++ b/test/tower_error_tracker_test.exs
@@ -219,7 +219,7 @@ defmodule TowerErrorTrackerTest do
     )
   end
 
-  test "Logger messages not reported because not supported by ErrorTracker" do
+  test "Logger messages reported as special custom exceptions (because messages not supported by ErrorTracker)" do
     in_unlinked_process(fn ->
       require Logger
 
@@ -228,7 +228,15 @@ defmodule TowerErrorTrackerTest do
       end)
     end)
 
-    assert [] = TestApp.Repo.all(ErrorTracker.Error) |> TestApp.Repo.preload(:occurrences)
+    assert_eventually(
+      [
+        %{
+          kind: "Elixir.TowerErrorTracker.ReportedMessage",
+          reason: "[emergency] Panic!",
+          occurrences: [_]
+        }
+      ] = TestApp.Repo.all(ErrorTracker.Error) |> TestApp.Repo.preload(:occurrences)
+    )
   end
 
   defp in_unlinked_process(fun) when is_function(fun, 0) do


### PR DESCRIPTION
closes #43 

Exploring here what could be a decent workaround `TowerErrorTracker` could have to address #43.

Not sure about adding something like this to be honest.
If merging, maybe having it turned off and only doing this based on an opt-in config option...?