### PR TITLE
feat: workaround for missing Logger messages (attempt 2)

### DIFF
--- a/lib/tower_error_tracker/reporter.ex
+++ b/lib/tower_error_tracker/reporter.ex
@@ -19,6 +19,13 @@ defmodule TowerErrorTracker.Reporter do
     :ok
   end
 
+  def report_event(%Tower.Event{kind: :message, reason: reason, level: level} = event) do
+    message = "[#{level}] #{reason}"
+    ErrorTracker.report({"message #{:erlang.phash2(message)}", message}, [], context(event))
+
+    :ok
+  end
+
   def report_event(_event) do
     :ignore
   end

--- a/test/tower_error_tracker_test.exs
+++ b/test/tower_error_tracker_test.exs
@@ -219,7 +219,7 @@ defmodule TowerErrorTrackerTest do
     )
   end
 
-  test "Logger messages not reported because not supported by ErrorTracker" do
+  test "Logger messages reported as special custom exceptions (because messages not supported by ErrorTracker)" do
     in_unlinked_process(fn ->
       require Logger
 
@@ -228,7 +228,18 @@ defmodule TowerErrorTrackerTest do
       end)
     end)
 
-    assert [] = TestApp.Repo.all(ErrorTracker.Error) |> TestApp.Repo.preload(:occurrences)
+    expected_reason = "[emergency] Panic!"
+    expected_kind = "message #{:erlang.phash2(expected_reason)}"
+
+    assert_eventually(
+      [
+        %{
+          kind: ^expected_kind,
+          reason: ^expected_reason,
+          occurrences: [_]
+        }
+      ] = TestApp.Repo.all(ErrorTracker.Error) |> TestApp.Repo.preload(:occurrences)
+    )
   end
 
   defp in_unlinked_process(fun) when is_function(fun, 0) do


### PR DESCRIPTION
closes #43 

alternative to #44 to fix https://github.com/mimiquate/tower_error_tracker/pull/44#discussion_r1949769461

---
![image](https://github.com/user-attachments/assets/aa16d978-4d12-4442-9753-7e8b3916d205)
